### PR TITLE
add support for alpha of all scrollbar and radius configuration

### DIFF
--- a/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollBarView/BRScrollBarView.h
+++ b/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollBarView/BRScrollBarView.h
@@ -31,6 +31,8 @@
 
 @property (nonatomic, readonly) BOOL isDragging;                           // if the user moving the handle
 @property (nonatomic, readonly) BOOL isScrollDirectionUp;
+@property (nonatomic, assign) float originAlpha;
+@property (nonatomic, assign) float cornerRadius;
 
 - (void)viewDidScroll:(UIScrollView *)scrollView;                               // called form the the Controller
 - (void)setBRScrollBarContentSizeForScrollView:(UIScrollView *)scrollView;      // called from the controller

--- a/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollBarView/BRScrollBarView.m
+++ b/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollBarView/BRScrollBarView.m
@@ -19,6 +19,16 @@
 @implementation BRScrollBarView
 @synthesize hideScrollBar = _hideScrollBar;
 
+-(void) setCornerRadius:(float)cornerRadius{
+    _cornerRadius = cornerRadius;
+    _scrollBarView.layer.cornerRadius = cornerRadius;
+}
+
+-(void) setOriginAlpha:(float)originAlpha{
+    _originAlpha = originAlpha;
+    _scrollBarView.alpha = originAlpha;
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
@@ -37,9 +47,11 @@
 
         self.backgroundColor = [UIColor clearColor];      // set me to transparent color iam just conatiner view
         _scrollBarView.backgroundColor = [UIColor lightGrayColor];  // set the background coolor to light gray
-        
+
+        self.originAlpha = 0.5;
         _scrollBarView.alpha = 0.7;
         _scrollBarView.layer.cornerRadius = 5;
+        self.cornerRadius = 5;
         
         _isDragging = NO;
         _showLabel = YES;
@@ -96,10 +108,10 @@
       
         [_fadingScrollBarTime invalidate];
         
-            if(self.alpha != 0.5)
+            if(self.alpha != self.originAlpha)
             {
                 [UIView animateWithDuration:0.3 animations:^{
-                    self.alpha = 0.5;
+                    self.alpha = self.originAlpha;
                 }];
             }
         

--- a/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollHandle/BRScrollHandle.h
+++ b/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollHandle/BRScrollHandle.h
@@ -18,6 +18,7 @@
 }
 
 @property (nonatomic, assign) CGFloat handleWidth;
+@property (nonatomic, assign) float cornerRadius;
 @property (nonatomic,readonly) CGFloat sizeDeference; // this property has the deference in size between MIN size and the
                                                       // needed size. This value will be used in the view did scroll and
                                                       // in handleDragged.

--- a/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollHandle/BRScrollHandle.m
+++ b/BRScrollBarViewDemo/BRScrollBarViewDemo/BRScrollBarClasses/BRScrollHandle/BRScrollHandle.m
@@ -48,6 +48,11 @@
 
 #pragma mark - Public
 
+-(void) setCornerRadius:(float)cornerRadius{
+    _cornerRadius = cornerRadius;
+    self.layer.cornerRadius = cornerRadius;
+}
+
 - (void)setHandleHeight:(CGFloat )height
 {
     CGRect myRect = self.frame;


### PR DESCRIPTION
example of the custom configuration: 

```
BRScrollBarController *brScrollbarSchool = [BRScrollBarController initForScrollView:self.tableView onPosition:kIntBRScrollBarPositionRight delegate:nil];
brScrollbarSchool.scrollBar.backgroundColor = [UIColor greenColor];
brScrollbarSchool.scrollBar.hideScrollBar = NO;
brScrollbarSchool.scrollBar.cornerRadius = 0;
brScrollbarSchool.scrollBar.originAlpha = 1;
brScrollbarSchool.scrollBar.scrollHandle.backgroundColor = [UIColor blackColor];
brScrollbarSchool.scrollBar.scrollHandle.alpha = 1;
brScrollbarSchool.scrollBar.scrollHandle.cornerRadius = 3;
```
